### PR TITLE
Fix bio heading closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       </div>
 
       <div id="bio" class="max-w-3xl 2xl:max-w-4xl mx-auto py-8 md:py-16 px-6 md:px-8">
-         <h1 class="text-md opacity-70 mb-4">About me</h2>
+         <h1 class="text-md opacity-70 mb-4">About me</h1>
          <h2 class="text-[24px] md:text-[32px] leading-[32px] md:leading-[40px] font-semibold">
             I’m a French Designer based in Biarritz 🌴, with over a decade of experience crafting products &amp; experiences that make an impact.<br><br>
             Currently, I lead Design at <a href="https://www.foundever.com/" class="text-link" target="_blank">Foundever</a>, where we develop AI-driven solutions to enhance customer support and streamline business operations.


### PR DESCRIPTION
## Summary
- correct the mismatched closing tag on the bio section heading to use </h1>

## Testing
- python index.html heading count script

------
https://chatgpt.com/codex/tasks/task_e_68cc28dfda748326936954df9ba6ebcc