### PR TITLE
Remove highlight animation from hero word

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
       </div>
 
       <div id="hero" class="max-w-3xl 2xl:max-w-4xl mx-auto py-8 pr-24 md:py-16 px-6 md:px-8 md:pr-16">
-         <h1 class="text-[40px] md:text-[64px] leading-[44px] md:leading-[72px] font-semibold 2xl:pr-16"><span class="word-animate ideas" style="--delay: 0s; box-shadow: -8px 0px 0px rgb(213, 233, 255), 8px 0px 0px rgb(213, 233, 255), -11px 0px 0px #007AFF, 11px 0px 0px #007AFF;">Designing</span> <span class="word-animate" style="--delay: 0.1s;">AI</span> <span class="word-animate" style="--delay: 0.2s;">products</span> <span class="word-animate" style="--delay: 0.3s;">that</span> <span class="word-animate" style="--delay: 0.4s;">survive</span> <span class="word-animate gradient" style="--delay: 0.5s;">reality.</span></h1>
+         <h1 class="text-[40px] md:text-[64px] leading-[44px] md:leading-[72px] font-semibold 2xl:pr-16"><span class="word-animate ideas" style="--delay: 0s;">Designing</span> <span class="word-animate" style="--delay: 0.1s;">AI</span> <span class="word-animate" style="--delay: 0.2s;">products</span> <span class="word-animate" style="--delay: 0.3s;">that</span> <span class="word-animate" style="--delay: 0.4s;">survive</span> <span class="word-animate gradient" style="--delay: 0.5s;">reality.</span></h1>
          <div class="text-md flex items-center mt-4 mt-8 mb-4mt-8 opportunities-animate">
             <div class="animate-ping rounded-full bg-green-500 h-[8px] w-[8px] inline-block mr-2 absolute"></div>
             <div class="rounded-full bg-green-500 h-[8px] w-[8px] inline-block mr-2"></div><span class="opacity-70">Open to opportunities</span>

--- a/style.css
+++ b/style.css
@@ -124,6 +124,8 @@ header {
     font-family: 'Inter Tight', sans-serif;
 }
 .ideas {
+    position: relative;
+    z-index: -1;
     display: inline-block;
     margin-right: 12px;
     opacity: 0;
@@ -131,10 +133,26 @@ header {
     animation-delay: calc(0.6s + var(--delay, 0s));
 }
 .ideas::before {
-    content: none;
+    content:"";
+    display: block;
+    position: absolute;
+    width:12px;
+    height:12px;
+    top:-11px;
+    left:-15.5px;
+    background-color: #007AFF;
+    border-radius: 8px;
 }
 .ideas::after {
-    content: none;
+    content:"";
+    display: block;
+    position: absolute;
+    width:12px;
+    height:12px;
+    bottom:-11px;
+    right:-15.5px;
+    background-color: #007AFF;
+    border-radius: 8px;
 }
 .gradient {
     --angle: 135deg;

--- a/style.css
+++ b/style.css
@@ -124,40 +124,17 @@ header {
     font-family: 'Inter Tight', sans-serif;
 }
 .ideas {
-    position: relative;
-    z-index:-1;
     display: inline-block;
     margin-right: 12px;
-    background-color: #d5e9ff;
-    background-image: linear-gradient(to right, #d5e9ff 0%, #d5e9ff 100%);
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
-    background-position: left center;
     opacity: 0;
     animation: wordFadeIn 0.8s ease-out forwards;
     animation-delay: calc(0.6s + var(--delay, 0s));
 }
 .ideas::before {
-    content:"";
-    display: block;
-    position: absolute;
-    width:12px;
-    height:12px;
-    top:-11px;
-    left:-15.5px;
-    background-color: #007AFF;
-    border-radius: 8px;
+    content: none;
 }
 .ideas::after {
-    content:"";
-    display: block;
-    position: absolute;
-    width:12px;
-    height:12px;
-    bottom:-11px;
-    right:-15.5px;
-    background-color: #007AFF;
-    border-radius: 8px;
+    content: none;
 }
 .gradient {
     --angle: 135deg;

--- a/style.css
+++ b/style.css
@@ -128,17 +128,14 @@ header {
     z-index:-1;
     display: inline-block;
     margin-right: 12px;
-    /* Apple-style highlight reveal animation */
-    /* Start with no background, then reveal it */
     background-color: #d5e9ff;
     background-image: linear-gradient(to right, #d5e9ff 0%, #d5e9ff 100%);
-    background-size: 0% 100%;
+    background-size: 100% 100%;
     background-repeat: no-repeat;
     background-position: left center;
     opacity: 0;
-    /* Separate animations: fade in first (matching other words), then reveal highlight */
-    animation: wordFadeIn 0.8s ease-out forwards, highlightReveal 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
-    animation-delay: calc(0.6s + var(--delay, 0s)), calc(0.6s + var(--delay, 0s) + 0.8s);
+    animation: wordFadeIn 0.8s ease-out forwards;
+    animation-delay: calc(0.6s + var(--delay, 0s));
 }
 .ideas::before {
     content:"";


### PR DESCRIPTION
## Summary
- remove the highlight reveal animation on the “Designing” word in the hero headline
- keep the word’s background styling static while retaining the fade-in timing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580bae8674832684891848a4bd56f0)