### PR TITLE
Remove animated ping and expand hero opportunities text

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,9 +59,8 @@
 
       <div id="hero" class="max-w-3xl 2xl:max-w-4xl mx-auto py-8 pr-24 md:py-16 px-6 md:px-8 md:pr-16">
          <h1 class="text-[40px] md:text-[64px] leading-[44px] md:leading-[72px] font-semibold 2xl:pr-16"><span class="word-animate ideas" style="--delay: 0s; background-color:#d5e9ff; box-shadow: -8px 0px 0px rgb(213, 233, 255), 8px 0px 0px rgb(213, 233, 255), -11px 0px 0px #007AFF, 11px 0px 0px #007AFF;">Designing</span> <span class="word-animate" style="--delay: 0.1s;">AI</span> <span class="word-animate" style="--delay: 0.2s;">products</span> <span class="word-animate" style="--delay: 0.3s;">that</span> <span class="word-animate" style="--delay: 0.4s;">survive</span> <span class="word-animate gradient" style="--delay: 0.5s;">reality.</span></h1>
-         <div class="text-md flex items-center mt-4 mt-8 mb-4mt-8 opportunities-animate">
-            <div class="animate-ping rounded-full bg-green-500 h-[8px] w-[8px] inline-block mr-2 absolute"></div>
-            <div class="rounded-full bg-green-500 h-[8px] w-[8px] inline-block mr-2"></div><span class="opacity-70">Open to opportunities</span>
+         <div class="text-md flex items-center mt-8 mb-4 opportunities-animate">
+            <span class="opacity-70">Design lead focused on AI products, strategy, and shipping work that holds up in the real world.</span>
          </div>
       </div>
       


### PR DESCRIPTION
### Motivation
- Remove a distracting animated indicator and provide a clearer, fuller statement about design leadership in the hero area.

### Description
- Edit `index.html` to remove the green ping elements (`animate-ping` and the green dot) and replace the short "Open to opportunities" label with a more descriptive sentence: "Design lead focused on AI products, strategy, and shipping work that holds up in the real world."

### Testing
- Started a local dev server with `python -m http.server 8000` and captured a visual verification screenshot using Playwright which produced `artifacts/hero-opportunities.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849d36569483268bbb163701aa2559)