### PR TITLE
Add progressive bottom blur overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
             </div>
          </div>
       </div>
-      <footer class="flex flex-row justify-between mt-8 max-w-3xl 2xl:max-w-4xl mx-auto pt-8 mt-16 px-6 md:px-8">
+      <footer id="footer" class="flex flex-row justify-between mt-8 max-w-3xl 2xl:max-w-4xl mx-auto pt-8 mt-16 px-6 md:px-8">
          <div>
             <p class="text-md opacity-60">© 2026 — Axel Wyart</p>
          </div>
@@ -669,6 +669,24 @@
                }, 1500);
             });
          }
+      </script>
+      <script>
+         (() => {
+            const bottomBlur = document.querySelector('.bottom-progressive-blur');
+            const footer = document.getElementById('footer');
+
+            if (!bottomBlur || !footer || !('IntersectionObserver' in window)) return;
+
+            const toggleBlur = ([entry]) => {
+               bottomBlur.classList.toggle('is-hidden', entry.isIntersecting);
+            };
+
+            const observer = new IntersectionObserver(toggleBlur, {
+               threshold: 0.01
+            });
+
+            observer.observe(footer);
+         })();
       </script>
       <div aria-hidden="true" class="bottom-progressive-blur"></div>
    </body>

--- a/index.html
+++ b/index.html
@@ -670,5 +670,6 @@
             });
          }
       </script>
+      <div aria-hidden="true" class="bottom-progressive-blur"></div>
    </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -26,10 +26,16 @@
   mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
   -webkit-mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
   background: linear-gradient(to top, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
+  opacity: 1;
+  transition: opacity 220ms ease;
 }
 
 .dark .bottom-progressive-blur {
   background: linear-gradient(to top, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+}
+
+.bottom-progressive-blur.is-hidden {
+  opacity: 0;
 }
 
 header {

--- a/style.css
+++ b/style.css
@@ -13,6 +13,25 @@
     
  }
 
+.bottom-progressive-blur {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: clamp(56px, 10vh, 128px);
+  pointer-events: none;
+  z-index: 50;
+  backdrop-filter: blur(1px);
+  -webkit-backdrop-filter: blur(1px);
+  mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+  -webkit-mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+  background: linear-gradient(to top, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
+}
+
+.dark .bottom-progressive-blur {
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+}
+
 header {
   opacity:0;
   animation:pageFadeIn 1s ease-in-out .2s;


### PR DESCRIPTION
### Motivation
- Add a subtle, progressive blur/fade at the bottom of the page so the page edge blends better with the background and content while scrolling.

### Description
- Added an `aria-hidden` overlay `<div class="bottom-progressive-blur"></div>` at the end of `index.html` and corresponding styles in `style.css` implementing a gradient mask, `backdrop-filter` blur, responsive height via `clamp()`, and a dark-mode variant under `.dark .bottom-progressive-blur`.

### Testing
- No automated tests were run because this repository does not contain an automated test suite; the change is a visual-only enhancement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d05f26a88326854ccb86e63629bb)