### PR TITLE
Fix z-index and animation timing for .ideas elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,11 +164,11 @@ header {
 }
 .ideas {
   position: relative;
-  z-index:-1;
+  z-index: 0;
   display: inline-block;
   margin-right: 12px;
   animation: wordFadeIn 0.8s ease-out forwards;
-  animation-delay: calc(0.6s + var(--delay, 0s)), calc(0.6s + var(--delay, 0s) + 0.8s);
+  animation-delay: calc(0.6s + var(--delay, 0s));
 }
 
 .ideas::before {
@@ -181,6 +181,7 @@ header {
     left:-15.5px;
     background-color: #007AFF;
     border-radius: 8px;
+    z-index: -1;
 }
 .ideas::after {
     content:"";
@@ -192,6 +193,7 @@ header {
     right:-15.5px;
     background-color: #007AFF;
     border-radius: 8px;
+    z-index: -1;
 }
 .gradient {
     --angle: 135deg;


### PR DESCRIPTION
### Motivation

- Ensure the `.ideas` element and its decorative pseudo-elements layer correctly and behave predictably during animations.

### Description

- Changed `.ideas` z-index from `-1` to `0` so the element is not pushed behind interactive/parent content.
- Simplified the `.ideas` `animation-delay` to a single `calc(0.6s + var(--delay, 0s))` to remove the duplicate delay declaration and avoid unintended timing overlap.
- Added `z-index: -1` to `.ideas::before` and `.ideas::after` so the decorative dots render behind the `.ideas` text while keeping the element itself on top.

### Testing

- Ran `stylelint` against `style.css` and there were no linting errors. 
- Performed a local build with `npm run build` to ensure CSS compiles and the site renders without errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e10557088326857418512c25578d)