### PR TITLE
Increase bottom blur and refine dark-mode fade

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,8 +21,8 @@
   height: clamp(56px, 10vh, 128px);
   pointer-events: none;
   z-index: 50;
-  backdrop-filter: blur(1px);
-  -webkit-backdrop-filter: blur(1px);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
   -webkit-mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
   background: linear-gradient(to top, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
@@ -31,7 +31,13 @@
 }
 
 .dark .bottom-progressive-blur {
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.92) 0%,
+    rgba(0, 0, 0, 0.62) 45%,
+    rgba(0, 0, 0, 0.2) 75%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .bottom-progressive-blur.is-hidden {


### PR DESCRIPTION
### Motivation
- Make the bottom progressive overlay more visible and prevent the dark-mode overlay from appearing to fade toward white by strengthening the blur and adjusting the dark gradient stops.

### Description
- Updated `style.css` to increase the bottom overlay blur from `blur(1px)` to `blur(14px)` and replaced the `.dark .bottom-progressive-blur` linear gradient with layered black alpha stops to keep the fade dark and smooth.

### Testing
- Ran `git diff --check` which reported no issues and verified the change applied to `style.css` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c709fb96b48326bacf332b24810eb1)