### PR TITLE
Fix bottom progressive blur for system dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,10 +21,11 @@
   height: clamp(56px, 10vh, 128px);
   pointer-events: none;
   z-index: 50;
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  background: linear-gradient(to top, rgba(255, 255, 255, 0.56), rgba(255, 255, 255, 0));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  background: linear-gradient(to top, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.65) 45%, rgba(255, 255, 255, 0.28) 75%, rgba(255, 255, 255, 0) 100%);
   will-change: backdrop-filter;
+  isolation: isolate;
   opacity: 1;
   transition: opacity 220ms ease;
 }
@@ -32,9 +33,9 @@
 .dark .bottom-progressive-blur {
   background: linear-gradient(
     to top,
-    rgba(0, 0, 0, 0.62) 0%,
-    rgba(0, 0, 0, 0.42) 45%,
-    rgba(0, 0, 0, 0.14) 75%,
+    rgba(0, 0, 0, 0.88) 0%,
+    rgba(0, 0, 0, 0.6) 45%,
+    rgba(0, 0, 0, 0.24) 75%,
     rgba(0, 0, 0, 0) 100%
   );
 }
@@ -43,9 +44,9 @@
   .bottom-progressive-blur {
     background: linear-gradient(
       to top,
-      rgba(0, 0, 0, 0.62) 0%,
-      rgba(0, 0, 0, 0.42) 45%,
-      rgba(0, 0, 0, 0.14) 75%,
+      rgba(0, 0, 0, 0.88) 0%,
+      rgba(0, 0, 0, 0.6) 45%,
+      rgba(0, 0, 0, 0.24) 75%,
       rgba(0, 0, 0, 0) 100%
     );
   }

--- a/style.css
+++ b/style.css
@@ -23,9 +23,8 @@
   z-index: 50;
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
-  -webkit-mask-image: linear-gradient(to top, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
-  background: linear-gradient(to top, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
+  background: linear-gradient(to top, rgba(255, 255, 255, 0.56), rgba(255, 255, 255, 0));
+  will-change: backdrop-filter;
   opacity: 1;
   transition: opacity 220ms ease;
 }
@@ -33,9 +32,9 @@
 .dark .bottom-progressive-blur {
   background: linear-gradient(
     to top,
-    rgba(0, 0, 0, 0.92) 0%,
-    rgba(0, 0, 0, 0.62) 45%,
-    rgba(0, 0, 0, 0.2) 75%,
+    rgba(0, 0, 0, 0.62) 0%,
+    rgba(0, 0, 0, 0.42) 45%,
+    rgba(0, 0, 0, 0.14) 75%,
     rgba(0, 0, 0, 0) 100%
   );
 }
@@ -44,9 +43,9 @@
   .bottom-progressive-blur {
     background: linear-gradient(
       to top,
-      rgba(0, 0, 0, 0.92) 0%,
-      rgba(0, 0, 0, 0.62) 45%,
-      rgba(0, 0, 0, 0.2) 75%,
+      rgba(0, 0, 0, 0.62) 0%,
+      rgba(0, 0, 0, 0.42) 45%,
+      rgba(0, 0, 0, 0.14) 75%,
       rgba(0, 0, 0, 0) 100%
     );
   }

--- a/style.css
+++ b/style.css
@@ -40,6 +40,18 @@
   );
 }
 
+@media (prefers-color-scheme: dark) {
+  .bottom-progressive-blur {
+    background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.92) 0%,
+      rgba(0, 0, 0, 0.62) 45%,
+      rgba(0, 0, 0, 0.2) 75%,
+      rgba(0, 0, 0, 0) 100%
+    );
+  }
+}
+
 .bottom-progressive-blur.is-hidden {
   opacity: 0;
 }


### PR DESCRIPTION
### Motivation
- The bottom progressive blur rendered a white-to-transparent gradient when the OS or browser preference is dark because only a class-based `.dark` rule existed and there was no `prefers-color-scheme` override.

### Description
- Add an `@media (prefers-color-scheme: dark)` rule that applies the same dark black-to-transparent gradient to `.bottom-progressive-blur` while keeping the existing `.dark .bottom-progressive-blur` rule for class-based dark mode.

### Testing
- Verified the stylesheet change with `git diff -- style.css` and inspected `style.css`, and the commit via `git commit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ae4b7804832683a723aa56ff8774)