### PR TITLE
Improve rendering and smoothing for `.ideas` animation in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -173,8 +173,14 @@ header {
   z-index: 0;
   display: inline-block;
   margin-right: 12px;
-  animation: wordFadeInNoBlur 0.8s ease-out forwards;
+  animation: wordFadeIn 0.8s ease-out forwards;
   animation-delay: calc(0.6s + var(--delay, 0s));
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: geometricPrecision;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0);
 }
 
 .ideas::before {
@@ -200,6 +206,7 @@ header {
     background-color: #007AFF;
     border-radius: 8px;
     z-index: -1;
+    filter: none;
 }
 .gradient {
     --angle: 135deg;
@@ -426,6 +433,13 @@ details.description summary::after {
     .date-work {
         display: none;
     }
+    .ideas {
+      position: relative;
+      z-index: 4;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      text-rendering: optimizeLegibility;
+    }
  }
 @media (prefers-color-scheme: dark) {
  .ideas {
@@ -510,7 +524,7 @@ details.description summary::after {
   to { 
     opacity: 1; 
     transform: translateY(0);
-    filter: blur(0);
+    filter: none;
   }
 }
 
@@ -534,7 +548,7 @@ details.description summary::after {
   to { 
     opacity: 1; 
     transform: translateY(0);
-    filter: blur(0);
+    filter: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce visual artifacts and improve text rendering during the `.ideas` animations by switching to the blur-aware animation and promoting the element to its own compositing layer.

### Description
- Change `.ideas` animation from `wordFadeInNoBlur` to `wordFadeIn` to enable the blur-to-none transition.
- Add font smoothing and rendering hints (`-webkit-font-smoothing`, `-moz-osx-font-smoothing`, `text-rendering`) and layer promotion (`transform: translateZ(0)`, `backface-visibility: hidden`) to `.ideas` for crisper text and better GPU compositing.
- Set `filter: none` on `.ideas::after` and replace `filter: blur(0)` with `filter: none` in `@keyframes` for `wordFadeIn` and `wordFadeInGradient` to avoid inconsistent filtering results.
- Add mobile-specific `.ideas` rules under `@media (max-width: 844px)` to ensure the smoothing and rendering adjustments apply on small screens.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b2c0e22483269557fe9eb11b9057)